### PR TITLE
Validate Page instance in afterExecute method

### DIFF
--- a/Plugin/Controller/Category/View.php
+++ b/Plugin/Controller/Category/View.php
@@ -22,6 +22,7 @@
 namespace Mageplaza\AjaxLayer\Plugin\Controller\Category;
 
 use Mageplaza\AjaxLayer\Helper\Data as LayerData;
+use Magento\Framework\View\Result\Page;
 
 /**
  * Class View
@@ -56,6 +57,10 @@ class View
      */
     public function afterExecute(\Magento\Catalog\Controller\Category\View $action, $page)
     {
+        if (!$page instanceof Page) {
+            return $page;
+        }
+        
         if ($this->_moduleHelper->ajaxEnabled() && $action->getRequest()->isAjax()) {
             $navigation = $page->getLayout()->getBlock('catalog.leftnav');
             $products   = $page->getLayout()->getBlock('category.products');


### PR DESCRIPTION
## Description
`Magento\Catalog\Controller\Category\View::execute()` does not always return a view page result. In some cases Magento can return other controller result types, such as `Magento\Framework\Controller\Result\Forward`.

The current plugin assumes that the result passed to `afterExecute()` is always a page result and calls:

```php
$page->getLayout()
```
This causes a fatal error when the category controller returns a forward result, because Forward does not implement getLayout().

## Production error example
We observed this in production on Magento 2.4.8:
```
[2026-05-15T08:37:48.501563+00:00] main.CRITICAL:
Error: Call to undefined method Magento\Framework\Controller\Result\Forward\Interceptor::getLayout() in /var/www/html/app/code/Mageplaza/AjaxLayer/Plugin/Controller/Category/View.php:57
```
Relevant stack trace:
```
#0 vendor/magento/framework/Interception/Interceptor.php(146):
   Mageplaza\AjaxLayer\Plugin\Controller\Category\View->afterExecute()

#1 vendor/magento/framework/Interception/Interceptor.php(153):
   Smartwave\Porto\Controller\Category\View\Interceptor->Magento\Framework\Interception\{closure}()

#3 vendor/magento/framework/App/Action/Action.php(111):
   Smartwave\Porto\Controller\Category\View\Interceptor->execute()
```